### PR TITLE
Update __init__.py

### DIFF
--- a/asyncpg_lite/__init__.py
+++ b/asyncpg_lite/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from typing import Optional, Union, Dict, List
-from sqlalchemy import MetaData, Table, Column, select, update, delete, Index
+from sqlalchemy import MetaData, Table, Column, select, update, delete, Index, DefaultClause
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql import and_, or_, func
@@ -140,6 +140,8 @@ class DatabaseManager:
             if default is not None:
                 if isinstance(default, str):
                     server_default = func.text(default)
+                elif isinstance(default, int):
+                    server_default = DefaultClause(str(default))
                 else:
                     server_default = func.text(str(default))
 


### PR DESCRIPTION
When using the create_table function and default Integer type, I get the error: asyncpg.exceptions.DatatypeMismatchError: column "count_refer" is of type integer, but the default expression type is text HINT: Rewrite the expression or convert its type.

columns = [
            {"name": "user_id", "type": BigInteger, "options": {"primary_key": True, "autoincrement": False}},
            {"name": "count_refer", "type": Integer,"options": {"default": 0, "server_default": 0}}
        ]

CREATE TABLE users_reg (
	user_id BIGINT, 
	count_refer INTEGER DEFAULT text('0')
)
